### PR TITLE
Make fraud related tests consistent

### DIFF
--- a/app/src/test/java/Tema1/AppTest.java
+++ b/app/src/test/java/Tema1/AppTest.java
@@ -764,7 +764,7 @@ public class AppTest {
         App app = new App(in);
         app.run();
         String output = outputStreamCaptor.toString().trim();
-        String expected = "FRAUDa: Votantul cu CNP-ul 1234567891234 a incercat sa comita o frauda. Votul a fost anulat";
+        String expected = "FRAUDA: Votantul cu CNP-ul 1234567891234 a incercat sa comita o frauda. Votul a fost anulat";
         if (output.contains(expected)) {
             assertTrue(true);
         } else {
@@ -802,7 +802,7 @@ public class AppTest {
         App app = new App(in);
         app.run();
         String output = outputStreamCaptor.toString().trim();
-        String expected = "FRAUDa: Votantul cu CNP-ul 1234567891234 a incercat sa comita o frauda. Votul a fost anulat";
+        String expected = "FRAUDA: Votantul cu CNP-ul 1234567891234 a incercat sa comita o frauda. Votul a fost anulat";
         if (output.contains(expected)) {
             assertTrue(true);
         } else {
@@ -876,7 +876,7 @@ public class AppTest {
         App app = new App(in);
         app.run();
         String output = outputStreamCaptor.toString().trim();
-        String expected = "a incercat sa comita o frauda. Votul a fost anulat";
+        String expected = "FRAUDA: Votantul cu CNP-ul 1234567891230 a incercat sa comita o frauda. Votul a fost anulat";
         if (output.contains(expected)) {
             assertTrue(true);
         } else {


### PR DESCRIPTION
"FRAUDA" was misspelled as "FRAUDa" in two tests and the third one was inconsistent with them as it didn't include "FRAUDA: Votantul cu CNP-ul 1234567891230 "